### PR TITLE
홈페이지 > 메인 페이지 동시에 다중으로 API 통신 기능 구현

### DIFF
--- a/src/Api/category.ts
+++ b/src/Api/category.ts
@@ -1,0 +1,3 @@
+import api from './api';
+
+export const getCategory = () => api.get('/channels');

--- a/src/Api/reviewPoster.ts
+++ b/src/Api/reviewPoster.ts
@@ -4,3 +4,6 @@ const SPECIFIED_CATEGORY_ID = '63bd045193836272216d31bc';
 
 export const getSpecifiedReviewPoster = () =>
   api.get(`/posts/channel/${SPECIFIED_CATEGORY_ID}`);
+
+export const getAllReviewPoster = (channelId: string) =>
+  api.get(`/posts/channel/${channelId}`);

--- a/src/Api/reviewPoster.ts
+++ b/src/Api/reviewPoster.ts
@@ -1,0 +1,6 @@
+import api from './api';
+
+const SPECIFIED_CATEGORY_ID = '63bd045193836272216d31bc';
+
+export const getSpecifiedReviewPoster = () =>
+  api.get(`/posts/channel/${SPECIFIED_CATEGORY_ID}`);

--- a/src/components/Home/Category/CategoryItem.tsx
+++ b/src/components/Home/Category/CategoryItem.tsx
@@ -25,11 +25,11 @@ const categoryIcon: CategoryNameAndIcon = {
   시계: IoWatchOutline,
 };
 
-const CategoryItem = ({ name, posts }: Category) => {
+const CategoryItem = ({ _id, name, posts }: Category) => {
   const Icon = categoryIcon[name];
 
   return (
-    <StyledLink to={`/category/${name}`}>
+    <StyledLink to={`/category/${name}`} state={{ id: _id, name }}>
       <section className="w-full flex flex-col items-start p-2.5 text-TEXT_BASE_BLACK border-BASE border rounded-xl cursor-pointer">
         <div className="border-BASE border-1 rounded-full p-2">
           <Icon className="text-xl" />

--- a/src/components/Home/Category/CategoryList.tsx
+++ b/src/components/Home/Category/CategoryList.tsx
@@ -3,38 +3,13 @@ import CategoryItem from '@/components/Home/Category/CategoryItem';
 import { useEffect, useState } from 'react';
 import api from '@/Api/api';
 
-const validCategoryName: CategoryName[] = [
-  '노트북',
-  '모니터',
-  '시계',
-  '오디오',
-  '키보드',
-  '휴대폰',
-];
-
-const CategoryList = () => {
-  const [category, setCategory] = useState<Category[]>();
-
-  useEffect(() => {
-    const getCategory = async () => {
-      try {
-        const response = (await api.get('/channels')).data as Category[];
-        const validCategory = response.filter((category) =>
-          validCategoryName.includes(category.name)
-        );
-
-        setCategory(validCategory);
-      } catch (e) {
-        console.log(e); // TODO: 에러처리..UI를 보여주는 건 어때? 새로고침하세요 모달이라던지
-      }
-    };
-    getCategory();
-  }, []);
-
+const CategoryList = ({ category }: { category: Category[] }) => {
   return (
-    <div className="flex flex-wrap justify-center gap-5 md:gap-6 lg:gap-6.5">
-      {category &&
-        category.map((category) => <CategoryItem key={category._id} {...category} />)}
+    <div>
+      <div className="flex flex-wrap justify-center gap-5 md:gap-6 lg:gap-6.5">
+        {category &&
+          category.map((category) => <CategoryItem key={category._id} {...category} />)}
+      </div>
     </div>
   );
 };

--- a/src/components/Home/ReviewPoster/index.tsx
+++ b/src/components/Home/ReviewPoster/index.tsx
@@ -1,24 +1,21 @@
 import { Link, useLocation } from 'react-router-dom';
-
-type ReviewPosterProps = {
-  id: string;
-  title: string;
-  image: string;
-};
+import { ReviewPosterDataType } from '@/types';
 
 // @param id - 선택한 포스터로 이동하기 위한 역할
 
-const ReviewPoster = ({ id, title, image }: ReviewPosterProps) => {
+const ReviewPoster = ({ id, title, image }: ReviewPosterDataType) => {
   const { pathname } = useLocation();
   // 다른 기능에서 사용하게 된다면 constants.ts로 옮기겠습니다.
   const BASE_CATEGORY_ROUTER_NAME = 'notebook';
-  const categoryPathName = pathname === '/' ? BASE_CATEGORY_ROUTER_NAME : pathname;
+  const SLASH_NUMBER = 1;
+  const categoryPathName =
+    pathname === '/' ? BASE_CATEGORY_ROUTER_NAME : pathname.slice(SLASH_NUMBER);
 
   return (
     // Link component는 a tag로 만들어졌는데 a tag안에서 div tag와 같은 block tag를 자식으로 가지고 있으면 semantic HTML이 아니지 않나요? 다른 팀원들의 의견이 궁금해요.
     <Link
       className="flex flex-col justify-center w-full h-60 md:h-64 lg:h-72 group cursor-pointer mb-5"
-      to={`/category/${categoryPathName}/detail`}
+      to={`/${categoryPathName}/detail`}
       state={{ id }}
     >
       <div className="relative h-full w-full overflow-hidden rounded-md group-hover:opacity-75">

--- a/src/components/ReviewList/ReviewCount.tsx
+++ b/src/components/ReviewList/ReviewCount.tsx
@@ -1,0 +1,10 @@
+const ReviewCount = ({ reviewCount }: { reviewCount: number }) => {
+  return (
+    <div className="pt-7 pb-5">
+      <span className="text-TEXT_BASE_BLACK text-lg lg:text-base">Showing</span>
+      <span className="text-BASE pl-2 text-lg lg:text-base">{reviewCount} reviews</span>
+    </div>
+  );
+};
+
+export default ReviewCount;

--- a/src/components/ReviewList/ReviewListHeader.tsx
+++ b/src/components/ReviewList/ReviewListHeader.tsx
@@ -1,0 +1,34 @@
+import useResize from '@/hooks/common/useResize';
+import { MOBILE_SCREEN } from '@/utils/constants';
+import styled from '@emotion/styled';
+
+const StyledH1 = styled.h1`
+  // @emotion으로 UI를 만드는 경우가 있으니 constants.ts에 자주 사용하는 color 넣어야하지 않을까요?
+  color: #261204;
+  font-weight: bold;
+  font-size: 1.5rem;
+  padding-top: 3rem;
+
+  @media (max-width: ${MOBILE_SCREEN}) {
+    border: 1px solid #ffc7c7;
+    border-radius: 1rem;
+    font-size: 1rem;
+    padding: 0.7rem 1.25rem;
+  }
+`;
+
+// className = 'border border-BASE text-TEXT_BASE_BLACK text-base font-bold py-2.5 px-5 rounded-2xl';
+const ReviewListHeader = ({ categoryName }: { categoryName: string }) => {
+  const { width } = useResize();
+
+  return (
+    <header className="flex lg:inline-block md:inline-block justify-center">
+      <StyledH1>{`리뷰 게시글 목록 ${
+        // '>' 아이콘으로 변경
+        width >= parseInt(MOBILE_SCREEN) ? `> ${categoryName}` : ''
+      }`}</StyledH1>
+    </header>
+  );
+};
+
+export default ReviewListHeader;

--- a/src/components/ReviewList/ReviewListSection.tsx
+++ b/src/components/ReviewList/ReviewListSection.tsx
@@ -1,0 +1,28 @@
+import { ReviewPosterDataType } from '@/types';
+import ReviewPoster from '@/components/Home/ReviewPoster';
+
+const ReviewListSection = ({
+  reviews,
+  reviewCount,
+}: {
+  reviews: ReviewPosterDataType[];
+  reviewCount: number;
+}) => {
+  if (reviewCount) {
+    return (
+      <ul className="">
+        {reviews.map(({ id, title, image }) => (
+          <ReviewPoster key={id} id={id} title={title} image={image} />
+        ))}
+      </ul>
+    );
+  } else {
+    return (
+      <div>
+        404 페이지로 이동(404 페이지에서 text만 리뷰 게시글이 없다고 알려주면 좋을 듯)
+      </div>
+    );
+  }
+};
+
+export default ReviewListSection;

--- a/src/hooks/common/useResize.tsx
+++ b/src/hooks/common/useResize.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useResize() {
+  const [windowSize, setWindowSize] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function onWindowResize() {
+      setWindowSize(getWindowDimensions());
+    }
+
+    // resize를 할때마다 handleResize가 실행되면서 성능 문제가 발생할 수 있다. 그래서 throttle을 사용해보자
+    window.addEventListener('resize', onWindowResize);
+
+    return () => window.removeEventListener('resize', onWindowResize);
+  }, []);
+
+  return windowSize;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@ body {
 
 #root {
   height: 100%;
+  min-height: 100vh;
   /* 메인 페이지에 패딩을 넣어주지 않으면 마지막 컴포넌트와 위치가 일치해지는 문제 발생... */
   padding-bottom: 100px;
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -3,51 +3,110 @@ import { InformLoginModal } from '@/components/Modal';
 import { informLoginModalState } from '@/store/store';
 import ReviewPoster from '@/components/Home/ReviewPoster';
 import CategoryList from '@/components/Home/Category/CategoryList';
+import { useEffect, useState } from 'react';
+import { Category, CategoryName } from '@/types';
+import { getCategory } from '@/Api/category';
+import { getSpecifiedReviewPoster } from '@/Api/reviewPoster';
 
-// UI test를 위한 더미 데이터
-const DUMMY_DATA = {
-  title: '맥북 강',
-  image:
-    'https://res.cloudinary.com/learnprogrammers/image/upload/v1673336085/post/6d8e6f95-d28a-4a47-bfe3-833bebd3ec98.jpg',
-  _id: '63bd151693836272216d3256',
-};
+type DataType = {
+  category: Category[];
+  specifiedPoster: {
+    id: string;
+    title: string;
+    image: string;
+  }[];
+} | null;
+
+const validCategoryName: CategoryName[] = [
+  '노트북',
+  '모니터',
+  '시계',
+  '오디오',
+  '키보드',
+  '휴대폰',
+];
 
 const Home = () => {
   const [open, setOpen] = useRecoilState(informLoginModalState);
+  const [data, setData] = useState<DataType>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(false);
   const titleClassName =
     'text-start sm:text-base md:text-lg lg:text-xl text-TEXT_BASE_BLACK font-semibold mb-2';
 
-  return (
-    <>
-      {/* 모바일 뷰에서만 보이는 임시 Logo 컴포넌트 레이아웃  */}
-      <h1
-        className={`md:hidden absolute top-5 left-1/2 -translate-x-1/2 text-5xl text-BASE font-extrabold`}
-      >
-        HIT
-      </h1>
-      <section className="flex flex-col items-center md:items-start lg:items-start max-w-xl w-full mx-auto pt-24 lg:pt-10 md:pt-10">
-        {/* 추천 게시글 area */}
-        <div className="w-11/12 h-full">
-          <h2 className={titleClassName}>추천 리뷰 게시글</h2>
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const getAllMainData = (
+          await Promise.all([getCategory(), getSpecifiedReviewPoster()])
+        ).map(({ data }) => data);
+        const categoryResponse: Category[] = getAllMainData[0];
+        const specifiedReviewPosterResponse: {
+          id: string;
+          title: string;
+          image: string;
+        }[] = getAllMainData[1];
+        const validCategory = categoryResponse.filter((category) =>
+          validCategoryName.includes(category.name)
+        );
+        const validSpecifiedReviewPosterResponse = specifiedReviewPosterResponse.slice(
+          0,
+          2
+        );
 
-          <ReviewPoster
-            id={DUMMY_DATA._id}
-            title={DUMMY_DATA.title}
-            image={DUMMY_DATA.image}
-          />
-          <ReviewPoster
-            id={DUMMY_DATA._id}
-            title={DUMMY_DATA.title}
-            image={DUMMY_DATA.image}
-          />
-          {/* 카테고리 목록 area */}
-          <h2 className={titleClassName}>카테고리</h2>
-          <CategoryList />
-        </div>
-      </section>
-      <InformLoginModal />
-    </>
-  );
+        setData({
+          category: validCategory,
+          specifiedPoster: validSpecifiedReviewPosterResponse,
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    run();
+  }, []);
+
+  if (loading) {
+    // 로딩 컴포넌트(스켈레톤)으로 대체
+    return null;
+  }
+
+  if (data) {
+    return (
+      <>
+        <h1
+          className={`md:hidden absolute top-5 left-1/2 -translate-x-1/2 text-5xl text-BASE font-extrabold`}
+        >
+          HIT
+        </h1>
+        <section className="flex flex-col items-center md:items-start lg:items-start max-w-xl w-full mx-auto pt-24 lg:pt-10 md:pt-10">
+          {/* 추천 게시글 area */}
+          <div className="w-11/12 h-full">
+            <h2 className={titleClassName}>추천 리뷰 게시글</h2>
+
+            <ReviewPoster
+              id={data?.specifiedPoster[0].id}
+              title={data?.specifiedPoster[0].title}
+              image={data?.specifiedPoster[0].image}
+            />
+            <ReviewPoster
+              id={data?.specifiedPoster[1].id}
+              title={data?.specifiedPoster[1].title}
+              image={data?.specifiedPoster[1].image}
+            />
+            {/* 카테고리 목록 area */}
+            <h2 className={titleClassName}>카테고리</h2>
+            <CategoryList category={data?.category} />
+          </div>
+        </section>
+        <InformLoginModal />
+      </>
+    );
+  }
 };
 
 export default Home;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -15,7 +15,7 @@ type DataType = {
     title: string;
     image: string;
   }[];
-} | null;
+};
 
 const validCategoryName: CategoryName[] = [
   '노트북',
@@ -28,7 +28,7 @@ const validCategoryName: CategoryName[] = [
 
 const Home = () => {
   const [open, setOpen] = useRecoilState(informLoginModalState);
-  const [data, setData] = useState<DataType>(null);
+  const [data, setData] = useState<DataType | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
   const titleClassName =

--- a/src/pages/ReviewList/index.tsx
+++ b/src/pages/ReviewList/index.tsx
@@ -1,7 +1,58 @@
-import React from 'react';
+import { getAllReviewPoster } from '@/Api/reviewPoster';
+import ReviewCount from '@/components/ReviewList/ReviewCount';
+import ReviewListHeader from '@/components/ReviewList/ReviewListHeader';
+import ReviewListSection from '@/components/ReviewList/ReviewListSection';
+import { ReviewPosterDataType } from '@/types';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const ReviewList = () => {
-  return <div>ReviewList</div>;
+  const [reviews, setReviews] = useState<ReviewPosterDataType[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(false);
+  const {
+    state: { id: channelId, name: categoryName },
+  } = useLocation();
+
+  const reviewCount = useMemo(() => reviews.length, [reviews]);
+
+  useEffect(() => {
+    const getReviewAllData = async () => {
+      try {
+        setLoading(true);
+        const response = await getAllReviewPoster(channelId);
+        const reviewListData = response.data.map(
+          ({ _id, title, image }: Omit<ReviewPosterDataType, 'id'>) => ({
+            id: _id,
+            title,
+            image,
+          })
+        );
+
+        setReviews(reviewListData);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getReviewAllData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  } else {
+    return (
+      <div className="pt-6 max-w-xl w-full h-full mx-auto px-6">
+        <ReviewListHeader categoryName={categoryName} />
+        <ReviewCount reviewCount={reviewCount} />
+        <ReviewListSection reviews={reviews} reviewCount={reviewCount} />
+      </div>
+    );
+  }
 };
 
 export default ReviewList;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -24,7 +24,7 @@ export type Category = {
 };
 
 // 타입 별칭 이름을 ReviewPoster로 작성하면 error가 발생한느 이유를 모르겠습니다.
-export type ReviewPosterDataType = {
+export type ReviewPosterType = {
   _id?: string;
   id: string;
   title: string;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -22,3 +22,11 @@ export type Category = {
   updatedAt: string;
   __v: number;
 };
+
+// 타입 별칭 이름을 ReviewPoster로 작성하면 error가 발생한느 이유를 모르겠습니다.
+export type ReviewPosterDataType = {
+  _id?: string;
+  id: string;
+  title: string;
+  image: string;
+};


### PR DESCRIPTION
## 💡 Linked Issues
- close: #25 
- close: #34 

## 📖 구현 내용
- 특정 채널의 포스트 목록 API + 채널 목록 API 동시에 데이터를 받아와서 화면에 보여주는 비지니스 로직 구현
-  특정 카테고리 리뷰 게시글 목록 UI 만들기
    - 특정 카테고리에 리뷰 게시글이 존재하는 UI
    - 특정 카테고리에 리뷰 게시글이 존재하지 않는 UI (최별님 404 Error 컴포넌트를 재사용할 예정)
- 특정 채널의 포스트 목록 API 데이터를 받아와서 화면에 보여주는 비지니스 로직 구현

## ✅ PR 포인트 & 궁금한 점
- 비지니스 로직과 UI 컴포넌트를 구분하는 로직에 대한 고민을 해보았고, 코드 리뷰 & PR merge 후에 미루지 않고 비지니스 로직과 UI 컴포넌트를 구분하는 리팩토링을 진행해야 합니다.
- 메인 페이지 기능 구현 후 바로 PR을 올리지 않고 리뷰 목록 리스트 페이지 기능을 구현한 점 반성하겠습니다. 🥹 (git 꼬임 문제가 발생할 수 있어서 제가 올린 PR 먼저 merge 해야 해요. 죄송합니다. 🥹🥹🥹)