### PR TITLE
카테고리 id,name 로컬스토리지로 관리 

### DIFF
--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://kdt.frontend.3rd.programmers.co.kr:5001',
+  baseURL: 'https://kdt.frontend.3rd.programmers.co.kr:5001',
 });
 
 export default api;

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -17,8 +17,8 @@ type HITAllDataType = {
   specifiedPoster: Omit<ExtractedReviewPosterType, '_id'>[];
 };
 
-// 공통화 어떻게 하면 좋을까요?
-function extractCategoryCondition(categories: Category[]) {
+// 공통화 어떻게 하면 좋을까요? -> utils로 빼는 게 나을 거 같은데
+export function extractCategoryCondition(categories: Category[]) {
   return categories.filter((category) => VALID_CATEGORY_NAME.includes(category.name));
 }
 

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -6,31 +6,18 @@ import { ExtractedReviewPosterType } from '@/types/review';
 
 import { categoryState } from '@/store/recoilCategoryState';
 
-import { VALID_CATEGORY_NAME } from '@/utils/constants';
-
 import { getCategory } from '@/Api/category';
 import { getSpecifiedReviewPoster } from '@/Api/reviewPoster';
-import { setCategoryNameAndIdStateToLocalStorage } from '@/utils/category';
+import {
+  extractValidCategory,
+  setCategoryNameAndIdStateToLocalStorage,
+} from '@/utils/category';
+import { extractRecommendReviewPoster } from '@/utils/review';
 
 type HITAllDataType = {
   category: Category[];
   specifiedPoster: Omit<ExtractedReviewPosterType, '_id'>[];
 };
-
-// 공통화 어떻게 하면 좋을까요? -> utils로 빼는 게 나을 거 같은데
-export function extractCategoryCondition(categories: Category[]) {
-  return categories.filter((category) => VALID_CATEGORY_NAME.includes(category.name));
-}
-
-function extractReviewPosterCondition(reviews: ExtractedReviewPosterType[]) {
-  const result = reviews.map(({ _id, title, image }) => ({
-    id: _id as string,
-    title,
-    image,
-  }));
-
-  return result.slice(0, 2);
-}
 
 const useFetchHIT = () => {
   const [data, setData] = useState<HITAllDataType | null>(null);
@@ -46,8 +33,8 @@ const useFetchHIT = () => {
         ]);
 
         setData({
-          category: extractCategoryCondition(categoryResponse),
-          specifiedPoster: extractReviewPosterCondition(reviewPosterResponse),
+          category: extractValidCategory(categoryResponse),
+          specifiedPoster: extractRecommendReviewPoster(reviewPosterResponse),
         });
         setCategory(categoryResponse as Category[]);
         setCategoryNameAndIdStateToLocalStorage(categoryResponse as Category[]);

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -10,6 +10,7 @@ import { VALID_CATEGORY_NAME } from '@/utils/constants';
 
 import { getCategory } from '@/Api/category';
 import { getSpecifiedReviewPoster } from '@/Api/reviewPoster';
+import { setCategoryNameAndIdStateToLocalStorage } from '@/utils/category';
 
 type HITAllDataType = {
   category: Category[];
@@ -49,6 +50,7 @@ const useFetchHIT = () => {
           specifiedPoster: extractReviewPosterCondition(reviewPosterResponse),
         });
         setCategory(categoryResponse as Category[]);
+        setCategoryNameAndIdStateToLocalStorage(categoryResponse as Category[]);
       } catch (error) {
         console.error(error);
       } finally {

--- a/src/pages/ReviewCreate/index.tsx
+++ b/src/pages/ReviewCreate/index.tsx
@@ -1,12 +1,18 @@
-import { useRecoilValue } from 'recoil';
-
-import { extractCategoryNameAndIdState } from '@/store/recoilCategoryState';
-
+import { useMemo } from 'react';
 import { InformLogOutModal } from '@/components/Modal';
 import ReviewCreateForm from '@/components/ReviewCreateForm';
+import { getLocalStorage } from '@/utils/storage';
+import { CATEGORY_ID_NAME } from '@/utils/constants';
+import { CategoryType } from '@/types';
 
 const ReviewCreate = () => {
-  const categoryData = useRecoilValue(extractCategoryNameAndIdState);
+  const categoryData: Readonly<CategoryType[]> = useMemo(() => {
+    const category = getLocalStorage(CATEGORY_ID_NAME);
+    if (!category) return [];
+    else {
+      return JSON.parse(category);
+    }
+  }, []);
 
   return (
     <div className="h-full pt-16">

--- a/src/store/recoilCategoryState.ts
+++ b/src/store/recoilCategoryState.ts
@@ -1,18 +1,7 @@
-import { atom, selector } from 'recoil';
-
+import { atom } from 'recoil';
 import { Category } from '@/types/category';
-import { CategoryType } from '@/types';
 
-export const categoryState = atom<Readonly<Category[]> | null>({
+export const categoryState = atom<Readonly<Category[]>>({
   key: 'CATEGORY_STATE',
-  default: null,
-});
-
-export const extractCategoryNameAndIdState = selector<CategoryType[]>({
-  key: 'EXTRACT_CATEGORY',
-  get: ({ get }) => {
-    const result = get(categoryState);
-
-    return result ? result.map(({ name, _id }) => ({ id: _id, name })) : [];
-  },
+  default: [],
 });

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,11 +1,13 @@
 import { Category } from '@/types/category';
 import { setLocalStorage, getLocalStorage } from '@/utils/storage';
 import { CATEGORY_ID_NAME } from '@/utils/constants';
+import { extractCategoryCondition } from '@/hooks/api/useFetchHIT';
 
 export const setCategoryNameAndIdStateToLocalStorage = (categoryState: Category[]) => {
-  const categoryNameAndId = categoryState.map(({ name, _id }) => ({ id: _id, name }));
-
   if (getLocalStorage(CATEGORY_ID_NAME)) return;
+
+  const validCategory = extractCategoryCondition(categoryState);
+  const categoryNameAndId = validCategory.map(({ name, _id }) => ({ id: _id, name }));
 
   setLocalStorage(CATEGORY_ID_NAME, JSON.stringify(categoryNameAndId));
 };

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,13 +1,17 @@
 import { Category } from '@/types/category';
 import { setLocalStorage, getLocalStorage } from '@/utils/storage';
 import { CATEGORY_ID_NAME } from '@/utils/constants';
-import { extractCategoryCondition } from '@/hooks/api/useFetchHIT';
+import { VALID_CATEGORY_NAME } from '@/utils/constants';
 
 export const setCategoryNameAndIdStateToLocalStorage = (categoryState: Category[]) => {
   if (getLocalStorage(CATEGORY_ID_NAME)) return;
 
-  const validCategory = extractCategoryCondition(categoryState);
+  const validCategory = extractValidCategory(categoryState);
   const categoryNameAndId = validCategory.map(({ name, _id }) => ({ id: _id, name }));
 
   setLocalStorage(CATEGORY_ID_NAME, JSON.stringify(categoryNameAndId));
+};
+
+export const extractValidCategory = (categories: Category[]) => {
+  return categories.filter((category) => VALID_CATEGORY_NAME.includes(category.name));
 };

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,0 +1,11 @@
+import { Category } from '@/types/category';
+import { setLocalStorage, getLocalStorage } from '@/utils/storage';
+import { CATEGORY_ID_NAME } from '@/utils/constants';
+
+export const setCategoryNameAndIdStateToLocalStorage = (categoryState: Category[]) => {
+  const categoryNameAndId = categoryState.map(({ name, _id }) => ({ id: _id, name }));
+
+  if (getLocalStorage(CATEGORY_ID_NAME)) return;
+
+  setLocalStorage(CATEGORY_ID_NAME, JSON.stringify(categoryNameAndId));
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,3 +37,6 @@ export const VALID_CATEGORY_NAME = [
   '키보드',
   '휴대폰',
 ] as CategoryName[];
+
+// local storage key
+export const CATEGORY_ID_NAME = 'category-id-name';

--- a/src/utils/review.ts
+++ b/src/utils/review.ts
@@ -1,0 +1,11 @@
+import { ExtractedReviewPosterType } from '@/types/review';
+
+export const extractRecommendReviewPoster = (reviews: ExtractedReviewPosterType[]) => {
+  const result = reviews.map(({ _id, title, image }) => ({
+    id: _id as string,
+    title,
+    image,
+  }));
+
+  return result.slice(0, 2);
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,6 @@
 const getLocalStorage = (key: string) => {
   try {
-    localStorage.getItem(key);
+    return localStorage.getItem(key);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
## 💡 Linked Issues
- close: #65 

## 📖 구현 내용
- 전역으로 관리하던 categoryState를 로컬스토리지에 세팅
- 전역관리 상태값을 쓰던 곳, 로컬스토리지로 대체 

## 반영 브랜치
dev
