### PR TITLE
기본 카테고리 노트북으로 변경 & 잘못된 카테고리 ID 수정

### DIFF
--- a/src/Api/reviewPoster.ts
+++ b/src/Api/reviewPoster.ts
@@ -2,7 +2,7 @@ import { ReviewPosterType } from '@/types';
 
 import api from './api';
 
-const SPECIFIED_CATEGORY_ID = '63bd141d93836272216d324a';
+const SPECIFIED_CATEGORY_ID = '63ca15bf0e665f5ec7433177';
 
 export const getSpecifiedReviewPoster = async (): Promise<ReviewPosterType[]> => {
   const { data } = await api.get<ReviewPosterType[]>(

--- a/src/components/Home/ReviewPoster/ReviewPoster.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPoster.tsx
@@ -5,14 +5,12 @@ import { ReviewPosterType } from '@/types';
 
 const ReviewPoster = ({ id, title, image }: ReviewPosterType) => {
   const { pathname } = useLocation();
-  // 다른 기능에서 사용하게 된다면 constants.ts로 옮기겠습니다.
-  const BASE_CATEGORY_ROUTER_NAME = 'category/오디오';
+  const BASE_CATEGORY_ROUTER_NAME = 'category/노트북';
   const SLASH_NUMBER = 1;
   const categoryPathName =
     pathname === '/' ? BASE_CATEGORY_ROUTER_NAME : pathname.slice(SLASH_NUMBER);
 
   return (
-    // Link component는 a tag로 만들어졌는데 a tag안에서 div tag와 같은 block tag를 자식으로 가지고 있으면 semantic HTML이 아니지 않나요? 다른 팀원들의 의견이 궁금해요.
     <Link
       className="flex flex-col justify-center w-full h-60 md:h-64 lg:h-72 group cursor-pointer mb-5"
       to={`/${categoryPathName}/detail`}

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
 
 import { Category } from '@/types/category';
 import { ExtractedReviewPosterType } from '@/types/review';
-
-import { categoryState } from '@/store/recoilCategoryState';
 
 import { getCategory } from '@/Api/category';
 import { getSpecifiedReviewPoster } from '@/Api/reviewPoster';
@@ -22,7 +19,6 @@ type HITAllDataType = {
 const useFetchHIT = () => {
   const [data, setData] = useState<HITAllDataType | null>(null);
   const [loading, setLoading] = useState(false);
-  const setCategory = useSetRecoilState(categoryState);
 
   useEffect(() => {
     const run = async () => {


### PR DESCRIPTION
## 💡 Linked Issues
- close: #77 

## 📖 구현 내용
- 기본 카테고리 Id 값 변경하기
- 잘못 삽입한 데이터 postman에서 삭제하기
- 기본 카테고리 오디오 -> 노트북으로 변경

## 반영 브랜치
`fix/invalid-category-id` -> `dev`

## ✅ PR 포인트 & 궁금한 점
