### PR TITLE
Avatar컴포넌트 확장(팔로우 알림일 경우, 유저 이미지 보여주도록)

### DIFF
--- a/src/components/Alarm/AlarmItem.tsx
+++ b/src/components/Alarm/AlarmItem.tsx
@@ -1,3 +1,4 @@
+import Avatar from '@/components/common/Avatar';
 import { AlarmItemType } from '@/types';
 import { getReviewContent } from '@/utils/alarm';
 import { getCategoryNameToMatchingId } from '@/utils/category';
@@ -56,12 +57,11 @@ const AlarmItemUI = ({
   linkState: { id: string };
   avatar?: boolean;
 }) => {
-  // FIXME: avatar 있을 때 보여주는 컴포넌트, 프로필 avatar 이미지 컴포넌트로 수정하기
   return (
     <Link to={link} state={linkState}>
       <div className="flex px-2 py-2 items-center justify-center">
         {avatar ? (
-          <img src={imageUrl} alt="유저이미지" className="mr-2 w-16 h-16 rounded-full" />
+          <Avatar image={imageUrl} size={16} style="mr-2" />
         ) : (
           <img src={imageUrl} alt="리뷰이미지" className="mr-2 w-16 h-16 rounded" />
         )}

--- a/src/components/Profile/UserProfile.tsx
+++ b/src/components/Profile/UserProfile.tsx
@@ -80,7 +80,7 @@ const UserProfile = () => {
   return (
     <div className="max-w-xl w-full my-0 mx-auto">
       <div className="flex flex-col items-center">
-        <Avatar user={user} size={36} />
+        <Avatar image={user.image} size={36} style="mt-10" />
         <div>{user.fullName || '해당 사용자가 없습니다.'}</div>
         <div>안녕하세요 월 수화 목금입니다.</div>
         <div onClick={() => alert('메세지를 보낼 수 없습니다')}>

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -33,7 +33,7 @@ const Profile = () => {
   return (
     <div className="max-w-xl w-full my-0 mx-auto">
       <div className="flex flex-col items-center">
-        <Avatar user={user} size={36} />
+        <Avatar image={user.image} size={36} style="mt-10" />
         <div>{user.fullName}</div>
         <div>안녕하세요 월 수화 목금입니다.</div>
         <Link to={EDIT_MY_PAGE}>

--- a/src/components/common/Avatar/index.tsx
+++ b/src/components/common/Avatar/index.tsx
@@ -1,15 +1,14 @@
-import { User } from '@/types';
-
 type AvatarProps = {
   size: number;
-  user: User;
+  image?: string;
+  style?: string;
 };
 
-const Avatar = ({ user, size }: AvatarProps) => {
+const Avatar = ({ image, size, style }: AvatarProps) => {
   return (
-    <div className="avatar mt-10">
+    <div className={`avatar ${style}`}>
       <div className={`w-${size} rounded-full`}>
-        <img src={user?.image || 'https://placeimg.com/200/200/arch'} />
+        <img src={image || 'https://placeimg.com/200/200/arch'} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📖 구현 내용
- avatar 컴포넌트 확장
- User 타입으로 묶인 것 -> imageUrl 로 수정 
- style을 주입받도록 수정 

## 🖼 구현 이미지
<img width="497" alt="스크린샷 2023-01-20 오후 2 30 04" src="https://user-images.githubusercontent.com/70274947/213624844-3106a40f-df76-4681-ba8b-1efd32ad6b88.png">

## 반영 브랜치
dev

## ✅ PR 포인트 & 궁금한 점
@guno517 기존 아바타 쓰던 곳 수정했는데, 놓친 거 없는지 체크 부탁드려용 
