### PR TITLE
리뷰 게시글에서 불필요한 정보 숨기기

### DIFF
--- a/src/Api/reviewPoster.ts
+++ b/src/Api/reviewPoster.ts
@@ -4,7 +4,7 @@ import { CATEGORY_DEFAULT_NOTEBOOK_ID } from '@/utils/constants';
 
 import api from './api';
 
-export const getSpecifiedReviewPoster = async (): Promise<ReviewPosterType[]> => {
+export const getSpecifiedReviewPoster = async () => {
   const { data } = await api.get<ReviewPosterType[]>(
     `/posts/channel/${CATEGORY_DEFAULT_NOTEBOOK_ID}`
   );
@@ -12,5 +12,8 @@ export const getSpecifiedReviewPoster = async (): Promise<ReviewPosterType[]> =>
   return data;
 };
 
-export const getAllReviewPoster = (channelId: string) =>
-  api.get(`/posts/channel/${channelId}`);
+export const getAllReviewPoster = async (channelId: string) => {
+  const { data } = await api.get<ReviewPosterType[]>(`/posts/channel/${channelId}`);
+
+  return data;
+};

--- a/src/components/Home/ReviewPoster/ReviewPoster.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPoster.tsx
@@ -15,11 +15,11 @@ const ReviewPoster = ({ id, title, image, author }: Omit<ReviewPosterType, '_id'
 
   return (
     <Link
-      className="flex flex-col justify-center w-full h-60 md:h-64 lg:h-72 group cursor-pointer mb-5"
+      className="flex flex-col justify-center w-full h-70 md:h-64 lg:h-72 group cursor-pointer mb-5"
       to={`/${categoryPathName}/detail`}
       state={{ id }}
     >
-      <div className="relative h-full w-full overflow-hidden rounded-md group-hover:opacity-75">
+      <div className="relative w-full h-60 overflow-hidden rounded-md group-hover:opacity-75">
         <img
           src={image}
           alt="review poster image"
@@ -28,7 +28,7 @@ const ReviewPoster = ({ id, title, image, author }: Omit<ReviewPosterType, '_id'
       </div>
 
       <div className="flex justify-between items-center pt-2 text-base">
-        <h3 className="text-base md:text-lg lg:text-xl font-semibold text-TEXT_BASE_BLACK">
+        <h3 className="w-3/4 truncate text-base md:text-lg lg:text-xl font-semibold text-TEXT_BASE_BLACK ">
           <span>{content.title}</span>
         </h3>
         <span className="font-medium text-TEXT_SUB_GRAY">{author.fullName}</span>

--- a/src/components/Home/ReviewPoster/ReviewPoster.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPoster.tsx
@@ -6,11 +6,12 @@ import { BASE_CATEGORY_ROUTER_NAME } from '@/utils/constants';
 
 // @param id - 선택한 포스터로 이동하기 위한 역할
 
-const ReviewPoster = ({ id, title, image }: ReviewPosterType) => {
+const ReviewPoster = ({ id, title, image, author }: Omit<ReviewPosterType, '_id'>) => {
   const { pathname } = useLocation();
   const SLASH_NUMBER = 1;
   const categoryPathName =
     pathname === '/' ? BASE_CATEGORY_ROUTER_NAME : pathname.slice(SLASH_NUMBER);
+  const content = JSON.parse(title);
 
   return (
     <Link
@@ -28,9 +29,9 @@ const ReviewPoster = ({ id, title, image }: ReviewPosterType) => {
 
       <div className="flex justify-between items-center pt-2 text-base">
         <h3 className="text-base md:text-lg lg:text-xl font-semibold text-TEXT_BASE_BLACK">
-          <span>{title}</span>
+          <span>{content.title}</span>
         </h3>
-        <span className="font-medium text-TEXT_SUB_GRAY">User Name</span>
+        <span className="font-medium text-TEXT_SUB_GRAY">{author.fullName}</span>
       </div>
     </Link>
   );

--- a/src/components/Home/ReviewPoster/ReviewPosterSection.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPosterSection.tsx
@@ -1,9 +1,9 @@
-import { ExtractedReviewPosterType } from '@/types/review';
+import { ReviewPosterType } from '@/types';
 
 import ReviewPoster from './ReviewPoster';
 
 type ReviewPosterSectionPropsType = {
-  specifiedPoster: Omit<ExtractedReviewPosterType, '_id'>[];
+  specifiedPoster: Omit<ReviewPosterType, '_id'>[];
   titleStyle: string;
 };
 
@@ -20,11 +20,13 @@ const ReviewPosterSection = ({
         id={firstSpecifiedPoster.id}
         title={firstSpecifiedPoster.title}
         image={firstSpecifiedPoster.image}
+        author={firstSpecifiedPoster.author}
       />
       <ReviewPoster
         id={lastSpecifiedPoster.id}
         title={lastSpecifiedPoster.title}
         image={lastSpecifiedPoster.image}
+        author={lastSpecifiedPoster.author}
       />
     </>
   );

--- a/src/components/ReviewList/ReviewListSection.tsx
+++ b/src/components/ReviewList/ReviewListSection.tsx
@@ -12,8 +12,8 @@ const ReviewListSection = ({
   if (reviewCount) {
     return (
       <ul className="">
-        {reviews.map(({ id, title, image }) => (
-          <ReviewPoster key={id} id={id} title={title} image={image} />
+        {reviews.map(({ id, title, image, author }) => (
+          <ReviewPoster key={id} id={id} title={title} image={image} author={author} />
         ))}
       </ul>
     );

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import { Category } from '@/types/category';
-import { ExtractedReviewPosterType } from '@/types/review';
 
 import { getCategory } from '@/Api/category';
 import { getSpecifiedReviewPoster } from '@/Api/reviewPoster';
@@ -10,10 +9,11 @@ import {
   setCategoryNameAndIdStateToLocalStorage,
 } from '@/utils/category';
 import { extractRecommendReviewPoster } from '@/utils/review';
+import { ReviewPosterType } from '@/types';
 
 type HITAllDataType = {
   category: Category[];
-  specifiedPoster: Omit<ExtractedReviewPosterType, '_id'>[];
+  specifiedPoster: Omit<ReviewPosterType, '_id'>[];
 };
 
 const useFetchHIT = () => {
@@ -28,11 +28,13 @@ const useFetchHIT = () => {
           getSpecifiedReviewPoster(),
         ]);
 
+        console.log(reviewPosterResponse);
+
         setData({
           category: extractValidCategory(categoryResponse),
           specifiedPoster: extractRecommendReviewPoster(reviewPosterResponse),
         });
-        setCategoryNameAndIdStateToLocalStorage(categoryResponse as Category[]);
+        setCategoryNameAndIdStateToLocalStorage(categoryResponse);
       } catch (error) {
         console.error(error);
       } finally {

--- a/src/hooks/api/useFetchHIT.tsx
+++ b/src/hooks/api/useFetchHIT.tsx
@@ -28,8 +28,6 @@ const useFetchHIT = () => {
           getSpecifiedReviewPoster(),
         ]);
 
-        console.log(reviewPosterResponse);
-
         setData({
           category: extractValidCategory(categoryResponse),
           specifiedPoster: extractRecommendReviewPoster(reviewPosterResponse),

--- a/src/pages/ReviewList/index.tsx
+++ b/src/pages/ReviewList/index.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ReviewList = () => {
-  const [reviews, setReviews] = useState<ReviewPosterType[]>([]);
+  const [reviews, setReviews] = useState<Omit<ReviewPosterType, '_id'>[]>([]);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
   const {
@@ -22,11 +22,12 @@ const ReviewList = () => {
       try {
         setLoading(true);
         const response = await getAllReviewPoster(channelId);
-        const reviewListData = response.data.map(
-          ({ _id, title, image }: Omit<ReviewPosterType, 'id'>) => ({
-            id: _id,
+        const reviewListData = response.map(
+          ({ _id, title, image, author }: Omit<ReviewPosterType, 'id'>) => ({
+            id: _id as string,
             title,
             image,
+            author,
           })
         );
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -114,12 +114,12 @@ export type ReviewFormData = {
   category: CategoryName;
 };
 
-// 타입 별칭 이름을 ReviewPoster로 작성하면 error가 발생하는 이유를 모르겠습니다.
 export type ReviewPosterType = {
   _id?: string;
   id: string;
   title: string;
   image: string;
+  author: User;
 };
 
 // 리뷰 게시글 상세페이지 타입
@@ -130,7 +130,7 @@ export type ReviewContentType = {
 
 // 리뷰 게시글 댓글 타입
 export type CommentType = {
-  author: User;
+  author: author;
   comment: string;
   createdAt: string;
   post: string;

--- a/src/utils/review.ts
+++ b/src/utils/review.ts
@@ -1,10 +1,11 @@
-import { ExtractedReviewPosterType } from '@/types/review';
+import { ReviewPosterType } from '@/types';
 
-export const extractRecommendReviewPoster = (reviews: ExtractedReviewPosterType[]) => {
-  const result = reviews.map(({ _id, title, image }) => ({
+export const extractRecommendReviewPoster = (reviews: ReviewPosterType[]) => {
+  const result = reviews.map(({ _id, title, image, author }) => ({
     id: _id as string,
     title,
     image,
+    author,
   }));
 
   return result.slice(0, 2);


### PR DESCRIPTION
## 💡 Linked Issues
- Resolve: #78 

## 📖 구현 내용
- 객체 형태의 문자열로 받아 오는 데이터에서 title, name 정보만을 추출해서 리뷰 게시글 화면에 뿌리기 (리뷰 게시글 데이터에서 title, name 값만 화면에 보여주기)
- 전체 리뷰 게시글 높이가 고정값으로 되어 있어서 레이아웃이 무너지는 현상 해결하기

## 🖼 구현 이미지
<img src="https://user-images.githubusercontent.com/57402711/213640066-806ad855-4919-45ef-98cc-72c8b52ccfd4.png" width="50%" />


## 반영 브랜치
`fix/review-poster-hide-impurit` -> `dev`

## ✅ PR 포인트 & 궁금한 점
- src/types에서 중복되는 타입이 많네요…. 리팩토링 1순위 같아요!
