### PR TITLE
리뷰 게시글을 선택하면 로그인 유무에 따라 Modal 보여 주는 기능

### DIFF
--- a/src/components/Home/ReviewPoster/ReviewPoster.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPoster.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { ReviewPosterType } from '@/types';
 

--- a/src/components/Home/ReviewPoster/ReviewPoster.tsx
+++ b/src/components/Home/ReviewPoster/ReviewPoster.tsx
@@ -1,8 +1,9 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { ReviewPosterType } from '@/types';
 
 import { BASE_CATEGORY_ROUTER_NAME } from '@/utils/constants';
+import useOpenAuthModal from '@/hooks/api/useOpenAuthModal';
 
 // @param id - 선택한 포스터로 이동하기 위한 역할
 
@@ -12,9 +13,13 @@ const ReviewPoster = ({ id, title, image, author }: Omit<ReviewPosterType, '_id'
   const categoryPathName =
     pathname === '/' ? BASE_CATEGORY_ROUTER_NAME : pathname.slice(SLASH_NUMBER);
   const content = JSON.parse(title);
+  const { onOpenLogInModal } = useOpenAuthModal(`/${categoryPathName}/detail`, {
+    state: { id },
+  });
 
   return (
     <Link
+      onClick={onOpenLogInModal}
       className="flex flex-col justify-center w-full h-70 md:h-64 lg:h-72 group cursor-pointer mb-5"
       to={`/${categoryPathName}/detail`}
       state={{ id }}

--- a/src/components/common/Feed/index.tsx
+++ b/src/components/common/Feed/index.tsx
@@ -1,3 +1,4 @@
+import useOpenAuthModal from '@/hooks/api/useOpenAuthModal';
 import { Link } from 'react-router-dom';
 
 import FeedItem from './FeedItem';
@@ -17,8 +18,11 @@ const Feed = ({
   firstFeedInformationCount,
   lastFeedInformationCount,
 }: FeedPropsType) => {
+  const { onOpenLogInModal } = useOpenAuthModal(categoryName, { state: { id: _id } });
+
   return (
     <Link
+      onClick={onOpenLogInModal}
       className="border-HOVER cursor-pointer relative overflow-hidden w-1/3 h-10/12"
       to={categoryName}
       state={{ id: _id }}

--- a/src/hooks/api/useOpenAuthModal.tsx
+++ b/src/hooks/api/useOpenAuthModal.tsx
@@ -1,0 +1,43 @@
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+
+import { informLoginModalState, informLogOutModalState } from '@/store/recoilModalState';
+
+import { checkAuthUser } from '@/Api/user';
+import React from 'react';
+
+const useOpenAuthModal = (pathname: string, options: { [key: string]: any }) => {
+  const navigate = useNavigate();
+  const setLogInModalOpened = useSetRecoilState(informLoginModalState);
+  const setLogOutModalOpened = useSetRecoilState(informLogOutModalState);
+
+  // useCallback으로 감싸야할까?
+  // T 제네릭을 공통 이벤트 타입으로 바꾸고 싶은데 방법이 뭘까?
+  // todo 중복 로직이 발생한다. 리팩토링을 진행해야 한다.
+  const onOpenLogInModal = <T extends React.MouseEvent<HTMLAnchorElement>>(e: T) => {
+    e.preventDefault();
+
+    (async () => {
+      const isLogIn = await checkAuthUser();
+      if (!isLogIn) {
+        setLogInModalOpened(true);
+      }
+
+      if (isLogIn) {
+        navigate(pathname, options);
+      }
+    })();
+  };
+
+  const onOpenLogOutModal = () => {
+    (async () => {
+      const isLogIn = await checkAuthUser();
+
+      if (isLogIn) setLogOutModalOpened(true);
+    })();
+  };
+
+  return { onOpenLogInModal, onOpenLogOutModal };
+};
+
+export default useOpenAuthModal;


### PR DESCRIPTION
## 💡 Linked Issues
- Resolve: #94 

📖 진행 사항
- 리뷰 게시글 클릭 시 로그인 유무 확인 후 모달 보여주는 기능 구현
- 검색한 피드 클릭 시 로그인 유무 확인 후 모달 보여주는 기능 구현
- useOpenAuthModal을 사용해서 중복 로직 제거

## 반영 브랜치
`feature/isLogin-modal` -> `dev`

## ✅ PR 포인트 & 궁금한 점
- useOpenAuthModal custom hook에서 T 제네릭을 공통 이벤트 타입으로 바꾸고 싶은데 방법이 뭘까?
- useOpenAuthModal custom hook을 `hooks/api`에 생성하면 좋을까요? 아니면 `hooks/common` 에 생성하면 좋을까요?
<img src="https://user-images.githubusercontent.com/57402711/213662872-a7fd7131-5178-4206-bb63-6f18656362df.png" width="50%" />



