### PR TITLE
검색 페이지 > 각 게시글 높이 통일 시키기

### DIFF
--- a/src/components/common/Feed/FeedItem.tsx
+++ b/src/components/common/Feed/FeedItem.tsx
@@ -28,7 +28,7 @@ const FeedItem = ({
   children,
 }: FeedItemPropsType) => {
   return (
-    <Figure className="w-100%">
+    <Figure className="w-100% h-40">
       {children}
       <figcaption className="flex w-full h-full items-center justify-around">
         <div className="flex gap-2 items-center">


### PR DESCRIPTION
## 💡 Linked Issues
- Resolve: #98 

## 📖 구현 내용
- 각 게시글 별 높이 공통화 작업

## 🖼 구현 이미지
<img src="https://user-images.githubusercontent.com/57402711/213678504-b0f331a2-4934-49fc-827f-df60b07a943f.png" width="50%" />

## 반영 브랜치
`design/search-unity-post-height` -> `dev`

## ✅ PR 포인트 & 궁금한 점
