### PR TITLE
검색 페이지 > 마이 프로필 라우터 -> 유저 프로필 라우터로 변경

### DIFF
--- a/src/components/Search/SearchUserFeed.tsx
+++ b/src/components/Search/SearchUserFeed.tsx
@@ -2,7 +2,7 @@ import { ExtractUserDataType } from '@/types/search';
 
 import Feed from '@/components/common/Feed';
 
-import { MY_PAGE } from '@/utils/constants';
+import { USER_PAGE } from '@/utils/constants';
 
 const SearchUserFeed = ({ searchedUser }: { searchedUser: ExtractUserDataType[] }) => {
   const UserFeedComponent = searchedUser.map((aSearchedUser) => {
@@ -10,7 +10,7 @@ const SearchUserFeed = ({ searchedUser }: { searchedUser: ExtractUserDataType[] 
 
     return (
       <Feed
-        categoryName={MY_PAGE}
+        categoryName={USER_PAGE}
         image={image}
         _id={_id}
         firstFeedInformationCount={posts.length}


### PR DESCRIPTION
## 💡 Linked Issues
- Resolve: #100 

## 📖 구현 내용
- 검색 결과 클릭 시 사용자 프로필로 이동하는 로직 구현 
- 마이 프로필 라우터 -> 유저 프로필 라우터로 변경

## 🖼 구현 이미지
https://user-images.githubusercontent.com/57402711/213681182-c9a5425e-556f-4a36-bdc0-3548a69f7972.mov

## 반영 브랜치
`fix/search-userInfo` -> `dev`

## ✅ PR 포인트 & 궁금한 점

