### PR TITLE
좋아요 버튼 디바운싱 구현

### DIFF
--- a/src/Api/like.ts
+++ b/src/Api/like.ts
@@ -1,11 +1,11 @@
 import api from './api';
 import { getAxiosHeader } from './user';
 
-const callCreateLikeAPI = async (callCreateLikeAPIBody: { postId: string }) => {
+const createLikeAPI = async (likeAPIBody: { postId: string }) => {
   try {
     const headers = getAxiosHeader();
     if (!headers) return false;
-    const { data } = await api.post('/likes/create', callCreateLikeAPIBody, {
+    const { data } = await api.post('/likes/create', likeAPIBody, {
       headers,
     });
 
@@ -15,7 +15,7 @@ const callCreateLikeAPI = async (callCreateLikeAPIBody: { postId: string }) => {
   }
 };
 
-const callDeleteLikeAPI = async (likeId: string) => {
+const deleteLikeAPI = async (likeId: string) => {
   try {
     const headers = getAxiosHeader();
     if (!headers) return false;
@@ -30,4 +30,4 @@ const callDeleteLikeAPI = async (likeId: string) => {
   }
 };
 
-export { callCreateLikeAPI, callDeleteLikeAPI };
+export { createLikeAPI, deleteLikeAPI };

--- a/src/components/common/LikeButton/index.tsx
+++ b/src/components/common/LikeButton/index.tsx
@@ -4,6 +4,7 @@ import { getUserInformation } from '@/Api/user';
 import { likeState } from '@/store/recoilLikeState';
 import { reviewDetailState } from '@/store/recoilReviewState';
 import { LIKE } from '@/utils/constants';
+import { isCheckedLike } from '@/utils/like';
 import { useState, useEffect, useRef } from 'react';
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import { useRecoilValue } from 'recoil';
@@ -18,17 +19,14 @@ const LikeButton = () => {
   const { author } = useRecoilValue(reviewDetailState);
 
   useEffect(() => {
+    const { isChecked, likeId } = isCheckedLike(likePropState?.likes, userId);
     const getUser = async () => {
       const user = await getUserInformation();
       setUserId(user._id);
     };
-    likePropState?.likes.forEach((like) => {
-      if (like.user === userId) {
-        setLikeToggle(true);
-        setLikeId(like._id);
-      } else setLikeToggle(false);
-    });
 
+    setLikeToggle(isChecked);
+    setLikeId(likeId);
     getUser();
   }, [userId]);
 

--- a/src/utils/like.ts
+++ b/src/utils/like.ts
@@ -1,0 +1,14 @@
+import { Like } from '@/types';
+
+// 로그인한 유저가 해당 게시글 좋아요 눌렀는지 true, false 반환
+export const isCheckedLike = (likePropState: Like[], userId: string) => {
+  let isChecked = false;
+  let likeId = '';
+
+  likePropState.some((like) => {
+    isChecked = like.user === userId;
+    likeId = like._id;
+  });
+
+  return { isChecked, likeId } as const;
+};


### PR DESCRIPTION
## 💡 Linked Issues
- close: #109 

## 📖 구현 내용
- 좋아요 버튼을 여러번 클릭해도 1번의 api호출만 보내는 디바운싱 구현

## 🖼 구현 이미지
![좋아요 버튼 성공](https://user-images.githubusercontent.com/64945491/214879284-e59a876c-ef51-491f-91a1-88d892f2cc6b.gif)

## 반영 브랜치
ex) refactor/like-button-> dev

## ✅ PR 포인트 & 궁금한 점
- @feel5ny 처음엔 멘토님이 알려주신 방법대로 구현해보니 똑같이 `likeToggle`의 상태를 바꾸는 코드라서 그런지 똑같은 현상이 발생하더라구요 ㅠ (제가 잘 이해를 못한것일수도 있습니다)
그래서 처음 `likeToggle`의 초기 상태를 받아오고 useRef로 플래그를 설정해주고, useEffect deps로 상태 변경하는 방식으로 했는데 이런 방식은 어떻게 생각하시나요??
- 또 팔로우, 언팔로우 하는 컴포넌트에서도 이 디바운싱 코드가 쓰일 수도 있다고 생각해서 custom hooks로 빼고 싶은데 감이 잘 안옵니다 ㅠㅠ 어떻게 재사용 할 수 있을까요??
